### PR TITLE
Modified linux serial_port library to work on Mac OS X

### DIFF
--- a/quan/platform/linux/serial_port.hpp
+++ b/quan/platform/linux/serial_port.hpp
@@ -20,8 +20,8 @@
 */
 
 
-#ifndef __linux 
-#error "only for use on linux"
+#if !defined(__linux) && !defined(__APPLE__)
+#error "only for use on linux or macOS"
 #endif
 
 
@@ -40,7 +40,11 @@
 
 //#include <termio.h>
 #include <err.h>
+
+#ifdef __linux
 #include <linux/serial.h>
+#endif
+
 #include <quan/concepts/port.hpp>
 #include <quan/is_model_of.hpp>
 #include <quan/time.hpp>

--- a/quan/serial_port.hpp
+++ b/quan/serial_port.hpp
@@ -17,7 +17,7 @@
  along with this program. If not, see http://www.gnu.org/licenses./
  */
 
-#ifdef __linux
+#if defined(__linux) || defined(__APPLE__)
 #include <quan/platform/linux/serial_port.hpp>
 #else
 #error need to write serial port code for this platform

--- a/quan_matters/src/serial_port.cpp
+++ b/quan_matters/src/serial_port.cpp
@@ -28,12 +28,16 @@
 
 //#include <termio.h>
 #include <err.h>
+
+#ifdef __linux
 #include <linux/serial.h>
+#include <linux/usbdevice_fs.h>
+#endif
+
 //#include <errno.h>
 //#include <string.h>
 
 #include <quan/serial_port.hpp>
-#include <linux/usbdevice_fs.h>
 #include <quan/utility/timer.hpp>
 
 quan::serial_port::serial_port( const char* filename)
@@ -209,8 +213,11 @@ int rate_to_constant(int baudrate)
 		B(50);     B(75);     B(110);    B(134);    B(150);
 		B(200);    B(300);    B(600);    B(1200);   B(1800);
 		B(2400);   B(4800);   B(9600);   B(19200);  B(38400);
-		B(57600);  B(115200); B(230400); B(460800); B(500000); 
-		B(576000); B(921600); B(1000000);B(1152000);B(1500000); 
+		B(57600);  B(115200); B(230400);
+#ifdef __linux
+        B(460800); B(500000);
+		B(576000); B(921600); B(1000000);B(1152000);B(1500000);
+#endif
 	default: return 0;
 	}
 #undef B


### PR DESCRIPTION
the only difference is that mac os x does not support as many baudrates as linux.
